### PR TITLE
june 2024 Security update

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -11,14 +11,14 @@
   <remote  name="aosp"
            fetch="https://android.googlesource.com"
            review="android-review.googlesource.com"
-           revision="refs/tags/android-14.0.0_r35" />
+           revision="refs/tags/android-14.0.0_r36" />
 
   <default revision="refs/heads/lineage-21.0"
            remote="github"
            sync-c="true"
            sync-j="4" />
 
-  <superproject name="platform/superproject" remote="aosp" revision="android-14.0.0_r35" />
+  <superproject name="platform/superproject" remote="aosp" revision="android-14.0.0_r36" />
   <contactinfo bugurl="go/repo-bug" />
 
   <!-- AOSP Projects -->

--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -74,7 +74,7 @@
   <project path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" name="LineageOS/android_prebuilts_gcc_linux-x86_aarch64_aarch64-linux-android-4.9" groups="pdk,linux,arm" clone-depth="1" revision="lineage-19.1" />
   <project path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" name="LineageOS/android_prebuilts_gcc_linux-x86_arm_arm-linux-androideabi-4.9" groups="pdk,linux,arm" clone-depth="1" revision="lineage-19.1" />
   <project path="prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" name="LineageOS/android_prebuilts_gcc_linux-x86_x86_x86_64-linux-android-4.9" groups="pdk,linux,x86" clone-depth="1" revision="lineage-19.1" />
-  <project path="prebuilts/kernel-build-tools" name="kernel/prebuilts/build-tools" clone-depth="1" remote="aosp" revision="refs/tags/android-14.0.0_r0.76" />
+  <project path="prebuilts/kernel-build-tools" name="kernel/prebuilts/build-tools" clone-depth="1" remote="aosp" revision="refs/tags/android-14.0.0_r0.77" />
   <project path="prebuilts/tools-lineage" name="LineageOS/android_prebuilts_tools-lineage" clone-depth="1" />
 
   <!-- CodeLinaro additions -->

--- a/snippets/pixel.xml
+++ b/snippets/pixel.xml
@@ -7,15 +7,15 @@
   <remote name="aosp-bluejay" fetch="https://android.googlesource.com" review="android-review.googlesource.com" revision="refs/tags/android-14.0.0_r34" clone-depth="1" />
 
   <!-- Pixel 7/7 Pro -->
-  <remote name="aosp-pantah" fetch="https://android.googlesource.com" review="android-review.googlesource.com" revision="refs/tags/android-14.0.0_r35" clone-depth="1" />
+  <remote name="aosp-pantah" fetch="https://android.googlesource.com" review="android-review.googlesource.com" revision="refs/tags/android-14.0.0_r36" clone-depth="1" />
   <!-- Pixel 7a -->
-  <remote name="aosp-lynx" fetch="https://android.googlesource.com" review="android-review.googlesource.com" revision="refs/tags/android-14.0.0_r35" clone-depth="1" />
+  <remote name="aosp-lynx" fetch="https://android.googlesource.com" review="android-review.googlesource.com" revision="refs/tags/android-14.0.0_r36" clone-depth="1" />
   <!-- Pixel Tablet -->
   <remote name="aosp-tangorpro" fetch="https://android.googlesource.com" review="android-review.googlesource.com" revision="refs/tags/android-14.0.0_r34" clone-depth="1" />
   <!-- Pixel Fold -->
-  <remote name="aosp-felix" fetch="https://android.googlesource.com" review="android-review.googlesource.com" revision="refs/tags/android-14.0.0_r35" clone-depth="1" />
+  <remote name="aosp-felix" fetch="https://android.googlesource.com" review="android-review.googlesource.com" revision="refs/tags/android-14.0.0_r36" clone-depth="1" />
 
   <!-- Pixel 8/8 Pro -->
-  <remote name="aosp-shusky" fetch="https://android.googlesource.com" review="android-review.googlesource.com" revision="refs/tags/android-14.0.0_r35" clone-depth="1" />
+  <remote name="aosp-shusky" fetch="https://android.googlesource.com" review="android-review.googlesource.com" revision="refs/tags/android-14.0.0_r36" clone-depth="1" />
 
 </manifest>


### PR DESCRIPTION
### June 2024 Security Update
**Summary**

**This pull request includes the necessary updates for the June 2024 security patch. Changes have been made to update the AOSP revision and kernel build tools to their latest versions.**

**Details**

1. Updated AOSP revision to android-14.0.0_r36 in default.xml and snippets/pixel.xml.
    Updated kernel build tools revision to android-14.0.0_r0.77 in snippets/lineage.xml.
    Ensured all references to Pixel devices have been updated to the latest AOSP revision where applicable.
    Files Changed
    default.xml

2. Updated AOSP revision from android-14.0.0_r35 to android-14.0.0_r36.
  Updated superproject revision from android-14.0.0_r35 to android-14.0.0_r36.
  snippets/lineage.xml
 
3. Updated kernel build tools revision from android-14.0.0_r0.76 to android-14.0.0_r0.77.
    snippets/pixel.xml
 
4. Updated various Pixel device revisions to android-14.0.0_r36.

Testing

- Test Sync: Ensure the repository syncs correctly with the updated revisions.
 
